### PR TITLE
Export host opts to allow for interfaces & mocking, update example

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -7,6 +7,12 @@ import (
 	"log"
 )
 
+type ProxySQLConn interface {
+	AddHost(...HostOpts) error
+	AddHosts(...*Host) error
+	PersistChanges() error
+}
+
 func main() {
 	// this is the dsn of the container that ./run.sh creates
 	conn, err := NewProxySQL("remote-admin:password@tcp(localhost:6032)/")
@@ -19,7 +25,20 @@ func main() {
 		log.Fatal(err)
 	}
 
-	err = conn.AddHost(Hostname("example"), HostgroupID(1))
+	AddHostsAndSave(conn)
+
+	entries, err := conn.All()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, entry := range entries {
+		log.Printf("entry: %v\n", entry)
+	}
+}
+
+func AddHostsAndSave(conn ProxySQLConn) {
+	err := conn.AddHost(Hostname("example"), HostgroupID(1))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -32,14 +51,5 @@ func main() {
 	err = conn.PersistChanges()
 	if err != nil {
 		log.Fatal(err)
-	}
-
-	entries, err := conn.All()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	for _, entry := range entries {
-		log.Printf("entry: %v\n", entry)
 	}
 }

--- a/example/example.go
+++ b/example/example.go
@@ -35,21 +35,24 @@ func main() {
 	for _, entry := range entries {
 		log.Printf("entry: %v\n", entry)
 	}
+
+	log.Println("Success")
 }
 
-func AddHostsAndSave(conn ProxySQLConn) {
+func AddHostsAndSave(conn ProxySQLConn) error {
 	err := conn.AddHost(Hostname("example"), HostgroupID(1))
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	err = conn.AddHosts(DefaultHost().SetHostname("example2"))
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	err = conn.PersistChanges()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
+	return nil
 }

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+)
+
+// Test functionality of AddHostsAndSave
+func TestAddHostsAndSaveErrorsOnConnectionFailure(t *testing.T) {
+	mock := NewProxySQLMock()
+	mock.healthy = false
+	err := AddHostsAndSave(mock)
+	if err == nil {
+		t.Fatal("AddHostsAndSave did not return error on ping fail")
+	}
+	t.Log(err)
+}

--- a/example/mock.go
+++ b/example/mock.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"errors"
+	. "github.com/kirinrastogi/proxysql-go"
+	"log"
+)
+
+type ProxySQLMock struct {
+	hosts   []*Host
+	healthy bool
+}
+
+func NewProxySQLMock() *ProxySQLMock {
+	return &ProxySQLMock{make([]*Host, 1), true}
+}
+
+func (p *ProxySQLMock) Ping() error {
+	if !p.healthy {
+		return errors.New("ping failed")
+	}
+	return nil
+}
+
+func (p *ProxySQLMock) AddHost(opts ...HostOpts) error {
+	for _, opt := range opts {
+		log.Println(opt)
+	}
+	return nil
+}
+
+func (p *ProxySQLMock) AddHosts(hosts ...*Host) error {
+	for _, host := range hosts {
+		log.Println(host)
+	}
+	return nil
+}
+
+func (p *ProxySQLMock) PersistChanges() error {
+	return p.Ping()
+}

--- a/proxysql.go
+++ b/proxysql.go
@@ -54,7 +54,7 @@ func (p *ProxySQL) PersistChanges() error {
 // with that configuration. This will return an error when a validation error
 // of the configuration you specified occurs.
 // This will propogate errors from sql.Exec as well
-func (p *ProxySQL) AddHost(opts ...hostOpts) error {
+func (p *ProxySQL) AddHost(opts ...HostOpts) error {
 	mut.Lock()
 	defer mut.Unlock()
 	hostq, err := buildAndParseHostQueryWithHostname(opts...)
@@ -104,7 +104,7 @@ func (p *ProxySQL) RemoveHost(host *Host) error {
 // RemoveHostsLike will remove all hosts that match the specified configuration
 // This will error if configuration does not pass validation
 // This will propogate error from sql.Exec
-func (p *ProxySQL) RemoveHostsLike(opts ...hostOpts) error {
+func (p *ProxySQL) RemoveHostsLike(opts ...HostOpts) error {
 	mut.Lock()
 	defer mut.Unlock()
 	hostq, err := buildAndParseHostQuery(opts...)
@@ -135,7 +135,7 @@ func (p *ProxySQL) RemoveHosts(hosts ...*Host) error {
 // HostsLike will return all hosts that match the given configuration
 // This will error on configuration validation failing
 // This will also propogate error from sql.Query, sql.Rows.Scan, sql.Rows.Err
-func (p *ProxySQL) HostsLike(opts ...hostOpts) ([]*Host, error) {
+func (p *ProxySQL) HostsLike(opts ...HostOpts) ([]*Host, error) {
 	mut.RLock()
 	defer mut.RUnlock()
 	hostq, err := buildAndParseHostQuery(opts...)
@@ -181,7 +181,7 @@ func (p *ProxySQL) HostsLike(opts ...hostOpts) ([]*Host, error) {
 // this with All(Table("runtime_mysql_servers"))
 // or just All() for "mysql_servers"
 // This will also propogate error from sql.Query, sql.Rows.Scan, sql.Rows.Err
-func (p *ProxySQL) All(opts ...hostOpts) ([]*Host, error) {
+func (p *ProxySQL) All(opts ...HostOpts) ([]*Host, error) {
 	// TODO: validation that only Table() was called
 	hostq, err := buildAndParseHostQuery(opts...)
 	if err != nil {

--- a/query.go
+++ b/query.go
@@ -22,7 +22,7 @@ type hostQuery struct {
 	specifiedFields []string
 }
 
-type hostOpts func(*hostQuery) *hostQuery
+type HostOpts func(*hostQuery) *hostQuery
 
 // given a slice of fields
 // returns a string like (sv_1, sv_2, sv_3)
@@ -100,7 +100,7 @@ func (opts *hostQuery) specifyField(field string) *hostQuery {
 }
 
 // Include this in a call to ProxySQL to specify 'hostgroup_id' in a query
-func HostgroupID(h int) hostOpts {
+func HostgroupID(h int) HostOpts {
 	return func(opts *hostQuery) *hostQuery {
 		return opts.HostgroupID(h)
 	}
@@ -108,77 +108,77 @@ func HostgroupID(h int) hostOpts {
 
 // Include this in a call to ProxySQL to specify
 // 'mysql_servers' or 'runtime_mysql_servers' in a query
-func Table(t string) hostOpts {
+func Table(t string) HostOpts {
 	return func(opts *hostQuery) *hostQuery {
 		return opts.Table(t)
 	}
 }
 
 // Include this in a call to ProxySQL to specify 'port' in a query
-func Port(p int) hostOpts {
+func Port(p int) HostOpts {
 	return func(opts *hostQuery) *hostQuery {
 		return opts.Port(p)
 	}
 }
 
 // Include this in a call to ProxySQL to specify 'hostname' in a query
-func Hostname(h string) hostOpts {
+func Hostname(h string) HostOpts {
 	return func(opts *hostQuery) *hostQuery {
 		return opts.Hostname(h)
 	}
 }
 
 // Include this in a call to ProxySQL to specify 'max_connections' in a query
-func MaxConnections(c int) hostOpts {
+func MaxConnections(c int) HostOpts {
 	return func(opts *hostQuery) *hostQuery {
 		return opts.MaxConnections(c)
 	}
 }
 
 // Include this in a call to ProxySQL to specify 'status' in a query
-func Status(s string) hostOpts {
+func Status(s string) HostOpts {
 	return func(opts *hostQuery) *hostQuery {
 		return opts.Status(s)
 	}
 }
 
 // Include this in a call to ProxySQL to specify 'weight' in a query
-func Weight(w int) hostOpts {
+func Weight(w int) HostOpts {
 	return func(opts *hostQuery) *hostQuery {
 		return opts.Weight(w)
 	}
 }
 
 // Include this in a call to ProxySQL to specify 'compression' in a query
-func Compression(c int) hostOpts {
+func Compression(c int) HostOpts {
 	return func(opts *hostQuery) *hostQuery {
 		return opts.Compression(c)
 	}
 }
 
 // Include this in a call to ProxySQL to specify 'max_replication_lag' in a query
-func MaxReplicationLag(m int) hostOpts {
+func MaxReplicationLag(m int) HostOpts {
 	return func(opts *hostQuery) *hostQuery {
 		return opts.MaxReplicationLag(m)
 	}
 }
 
 // Include this in a call to ProxySQL to specify 'use_ssl' in a query
-func UseSSL(u int) hostOpts {
+func UseSSL(u int) HostOpts {
 	return func(opts *hostQuery) *hostQuery {
 		return opts.UseSSL(u)
 	}
 }
 
 // Include this in a call to ProxySQL to specify 'max_latency_ms' in a query
-func MaxLatencyMS(m int) hostOpts {
+func MaxLatencyMS(m int) HostOpts {
 	return func(opts *hostQuery) *hostQuery {
 		return opts.MaxLatencyMS(m)
 	}
 }
 
 // Include this in a call to ProxySQL to specify 'comment' in a query
-func Comment(c string) hostOpts {
+func Comment(c string) HostOpts {
 	return func(opts *hostQuery) *hostQuery {
 		return opts.Comment(c)
 	}
@@ -254,7 +254,7 @@ func defaultHostQuery() *hostQuery {
 	}
 }
 
-func buildAndParseHostQuery(setters ...hostOpts) (*hostQuery, error) {
+func buildAndParseHostQuery(setters ...HostOpts) (*hostQuery, error) {
 	opts := defaultHostQuery()
 	for _, setter := range setters {
 		setter(opts)
@@ -269,7 +269,7 @@ func buildAndParseHostQuery(setters ...hostOpts) (*hostQuery, error) {
 }
 
 // same as above but mandatory hostname
-func buildAndParseHostQueryWithHostname(setters ...hostOpts) (*hostQuery, error) {
+func buildAndParseHostQueryWithHostname(setters ...HostOpts) (*hostQuery, error) {
 	opts, err := buildAndParseHostQuery(setters...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This allows the user to define an interface, accept this interface in their code, and then create mocks that adhere to this interface for testing.

The example was updated to include

a `mock.go` file which shows the user how to create a mock with stubbed functions

a `example_test.go` file which shows how to write a test that calls code with a mock that adheres to the defined interface

